### PR TITLE
Detect generic dialect for custom driver subclasses

### DIFF
--- a/src/main/scala/slick/migration/api/Dialect.scala
+++ b/src/main/scala/slick/migration/api/Dialect.scala
@@ -295,12 +295,12 @@ class PostgresDialect extends Dialect[PostgresProfile] {
 object GenericDialect {
 
   def apply(driver: JdbcProfile): Dialect[_ <: JdbcProfile] = driver match {
-    case DerbyProfile    => new DerbyDialect
-    case H2Profile       => new H2Dialect
-    case SQLiteProfile   => new SQLiteDialect
-    case HsqldbProfile   => new HsqldbDialect
-    case MySQLProfile    => new MySQLDialect
-    case PostgresProfile => new PostgresDialect
+    case _: DerbyProfile    => new DerbyDialect
+    case _: H2Profile       => new H2Dialect
+    case _: SQLiteProfile   => new SQLiteDialect
+    case _: HsqldbProfile   => new HsqldbDialect
+    case _: MySQLProfile    => new MySQLDialect
+    case _: PostgresProfile => new PostgresDialect
     case _ =>
       throw new IllegalArgumentException("Slick error : Unknown or unsupported jdbc driver found.")
   }

--- a/src/test/scala/slick/migration/api/GenericDialectTest.scala
+++ b/src/test/scala/slick/migration/api/GenericDialectTest.scala
@@ -1,0 +1,13 @@
+package slick.migration.api
+
+import org.scalatest.{FunSuite, Matchers}
+import slick.jdbc.H2Profile
+
+class GenericDialectTest extends FunSuite with Matchers {
+  test("detect dialect for custom drivers") {
+    object CustomH2Profile extends H2Profile
+
+    GenericDialect(H2Profile) shouldBe a [H2Dialect]
+    GenericDialect(CustomH2Profile) shouldBe a [H2Dialect]
+  }
+}


### PR DESCRIPTION
It's common to subclass the driver, for example when using https://github.com/tminglei/slick-pg