### PR TITLE
Update sbt-scoverage to 1.6.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,2 @@
-resolvers += Classpaths.sbtPluginReleases
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")


### PR DESCRIPTION
Mainly for scala 2.13.0 support

Also remove `resolvers += Classpaths.sbtPluginReleases`, I don't think it's needed