### PR TITLE
Fix with description comparison as found with the flyway extension

### DIFF
--- a/src/main/scala/slick/migration/api/TableMigration.scala
+++ b/src/main/scala/slick/migration/api/TableMigration.scala
@@ -84,9 +84,7 @@ object TableMigration {
         }
       }
     }
-    override def toString: String = {
-      "Reversible " + this.underlying.toString
-    }
+    override def toString = underlying.toString
   }
 
   implicit def toReversible[T <: JdbcProfile#Table[_]]: ToReversible[TableMigration[T, Action.Reversible]] =

--- a/src/main/scala/slick/migration/api/TableMigration.scala
+++ b/src/main/scala/slick/migration/api/TableMigration.scala
@@ -84,6 +84,9 @@ object TableMigration {
         }
       }
     }
+    override def toString: String = {
+      "Reversible " + this.underlying.toString
+    }
   }
 
   implicit def toReversible[T <: JdbcProfile#Table[_]]: ToReversible[TableMigration[T, Action.Reversible]] =


### PR DESCRIPTION
Fixed TableMigration Reversible class to have an explicit toString in order to be sure that description comparisons in the flyway extension
work as expected.

See https://github.com/nafg/slick-migration-api-flyway/pull/27 for a test showing the issue