### PR TITLE
CI: bump JDK to temurin@17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.x, 2.13.x, 3.3.x]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -32,12 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt
@@ -69,7 +69,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.3.8]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -77,12 +77,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,9 +8,9 @@ pull_request_rules:
       - or:
           - author=scala-steward
           - author=nafg-scala-steward[bot]
-      - check-success=Build and Test (ubuntu-latest, 2.12.x, temurin@11)
-      - check-success=Build and Test (ubuntu-latest, 2.13.x, temurin@11)
-      - check-success=Build and Test (ubuntu-latest, 3.3.x, temurin@11)
+      - check-success=Build and Test (ubuntu-latest, 2.12.x, temurin@17)
+      - check-success=Build and Test (ubuntu-latest, 2.13.x, temurin@17)
+      - check-success=Build and Test (ubuntu-latest, 3.3.x, temurin@17)
     actions:
         queue:
             name: default

--- a/ci.sbt
+++ b/ci.sbt
@@ -14,7 +14,7 @@ inThisBuild(List(
   ),
   dynverGitDescribeOutput ~= (_.map(o => o.copy(dirtySuffix = sbtdynver.GitDirtySuffix("")))),
   dynverSonatypeSnapshots := true,
-  githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11")),
+  githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17")),
   githubWorkflowScalaVersions := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\d+$", "x")),
   githubWorkflowTargetTags ++= Seq("v*"),
   githubWorkflowBuild := Seq(


### PR DESCRIPTION
The generated workflow was pinned to `temurin@11`. sbt 2.x requires JDK 17+, so scala-steward's "Update sbt to 2.0.x" PR cannot pass CI on JDK 11.

This sets `githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))` in `ci.sbt` and regenerates `.github/workflows/ci.yml` (and `.mergify.yml`, via sbt-mergify-github-actions, whose `check-success` names embed the java version). `project/build.properties` is untouched — the sbt bump stays scala-steward's PR.

Verified locally on temurin 17: `githubWorkflowCheck` passes, and `+test` (against the docker-compose mysql/postgres, `testkit-github.conf`) passes on 2.12.21, 2.13.18, and 3.3.8 — 79 tests each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)